### PR TITLE
fix(style): 🐛 🎨 u-body5 leading

### DIFF
--- a/packages/components/windi.config.ts
+++ b/packages/components/windi.config.ts
@@ -53,7 +53,8 @@ export default defineConfig({
     'u-body3': 'font-opensans font-bold tracking-normal text-[16px] text-grey1 leading-5 italic',
     'u-body3-pure': 'font-opensans font-bold tracking-normal text-[16px] leading-5 italic',
     'u-body4': 'font-opensans font-semibold tracking-normal text-[14px] text-grey1 leading-5',
-    'u-body5': 'font-opensans font-bold tracking-normal text-[12px] text-grey1 leading-3.5 italic',
+    'u-body5':
+      'font-opensans font-bold tracking-normal text-[12px] text-grey1 leading-0.875rem italic',
     'u-caption': 'font-opensans font-normal tracking-normal text-[14px] text-grey1 leading-5',
     'u-tag': 'font-opensans font-normal tracking-normal text-[12px] text-grey1 leading-4',
     'u-tag2': 'font-opensans font-semibold tracking-normal text-[12px] text-grey1 leading-4'


### PR DESCRIPTION
### What does this PR do? 一句话概括这次提交的内容

全局字体中的u-body5行高14px，错误的设置成了leading-3.5，改为leading-0.875rem

### All Submissions: 自检

- [ ] Have you done eslint + stylelint? 是否完成代码检查？
- [ ] Have you add necessary comments? 是否添加了必要的注释？
- [ ] Have you checked the business flow? 是否完成业务的自检？
